### PR TITLE
Fix launch status

### DIFF
--- a/modules/cucumber-reportportal-formatter.js
+++ b/modules/cucumber-reportportal-formatter.js
@@ -560,7 +560,7 @@ const createRPFormatterClass = (config) => {
         if (this.context.launchId) {
           const finishLaunchRQ = {
             endTime: this.reportportal.helpers.now(),
-            status: event.result.status ? STATUSES.PASSED : STATUSES.FAILED,
+            status: event.result.success ? STATUSES.PASSED : STATUSES.FAILED,
           };
 
           if (this.context.launchStatus) {


### PR DESCRIPTION
Currently, the lunch of every status we run is set as failed since `event.result.status` doesn't exist so it's always false.

The actual objct is: event.result = {
  "duration": timestamp,
  "success": boolean
}