### PR TITLE
fix: reset testCase status on retry to correctly report passed

### DIFF
--- a/modules/cucumber-reportportal-formatter.js
+++ b/modules/cucumber-reportportal-formatter.js
@@ -236,7 +236,7 @@ const createRPFormatterClass = (config) =>
       let isRetry = isTestCaseRetried;
       if (attempt > 0) {
         isRetry = true;
-        this.storage.updateTestCase(testCaseId, { isRetry });
+        this.storage.updateTestCase(testCaseId, { isRetry, status: undefined });
 
         // do not show scenario with retry in RP
         if (!this.isScenarioBasedStatistics) return;


### PR DESCRIPTION
[Issue: Retry scenario status remains "FAILED" even when all steps pass on retry](https://github.com/reportportal/agent-js-cucumber/issues/193)

When scenarioBasedStatistics is enabled and a scenario is retried,
testCase.status retains the FAILED value from the previous attempt.
If all steps pass on retry, the stale status is never overwritten,
causing the final status to be incorrectly reported as FAILED.

Reset testCase.status to undefined at the start of each retry attempt
so the fallback logic in onTestCaseFinishedEvent correctly resolves
to PASSED when all steps succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry test case handling in reporting to ensure proper status management during retry initialization, enhancing accuracy of test retry information in reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->