### PR TITLE
EPMRPP-117079 || Introduce a code knowledge graph for search/read operations

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -1,0 +1,20 @@
+# Dev Guide
+
+Internal notes for contributors. This content is intentionally kept out of
+README.md, which is published to package registries.
+
+## Code knowledge graph
+
+This repo carries a local **code knowledge graph** ([colbymchenry/codegraph](https://github.com/colbymchenry/codegraph))
+that the ReportPortal AI agents (and your own tooling) use to resolve symbols and
+references without scanning raw files.
+
+```bash
+npm run codegraph             # build it the first time, fast incremental sync after
+npm run codegraph -- --force  # rebuild from scratch
+```
+
+The graph lives in `.codegraph/codegraph.db` — it is **gitignored and local to your
+machine** (only `.codegraph/.gitignore` is committed). It is a pure derivative of the
+source, so regenerate it any time. The engine is fetched on demand via `npx`, so there
+is no added project dependency.

--- a/README.md
+++ b/README.md
@@ -405,3 +405,18 @@ Then(/^I should see my new task in the list$/, function() {
 
 Licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html)
 license (see the LICENSE.txt file).
+## Code knowledge graph
+
+This repo carries a local **code knowledge graph** ([colbymchenry/codegraph](https://github.com/colbymchenry/codegraph))
+that the ReportPortal AI agents (and your own tooling) use to resolve symbols and
+references without scanning raw files.
+
+```bash
+npm run codegraph             # build it the first time, fast incremental sync after
+npm run codegraph -- --force  # rebuild from scratch
+```
+
+The graph lives in `.codegraph/codegraph.db` — it is **gitignored and local to your
+machine** (only `.codegraph/.gitignore` is committed). It is a pure derivative of the
+source, so regenerate it any time. The engine is fetched on demand via `npx`, so there
+is no added project dependency.

--- a/README.md
+++ b/README.md
@@ -405,7 +405,3 @@ Then(/^I should see my new task in the list$/, function() {
 
 Licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html)
 license (see the LICENSE.txt file).
-
-## Code knowledge graph
-
-See [DEV_GUIDE.md](DEV_GUIDE.md#code-knowledge-graph) for details on the local code knowledge graph used by contributor tooling.

--- a/README.md
+++ b/README.md
@@ -405,18 +405,7 @@ Then(/^I should see my new task in the list$/, function() {
 
 Licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html)
 license (see the LICENSE.txt file).
+
 ## Code knowledge graph
 
-This repo carries a local **code knowledge graph** ([colbymchenry/codegraph](https://github.com/colbymchenry/codegraph))
-that the ReportPortal AI agents (and your own tooling) use to resolve symbols and
-references without scanning raw files.
-
-```bash
-npm run codegraph             # build it the first time, fast incremental sync after
-npm run codegraph -- --force  # rebuild from scratch
-```
-
-The graph lives in `.codegraph/codegraph.db` — it is **gitignored and local to your
-machine** (only `.codegraph/.gitignore` is committed). It is a pure derivative of the
-source, so regenerate it any time. The engine is fetched on demand via `npx`, so there
-is no added project dependency.
+See [DEV_GUIDE.md](DEV_GUIDE.md#code-knowledge-graph) for details on the local code knowledge graph used by contributor tooling.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Agent that connects cucumber-js with Report Portal",
   "main": "./modules/index",
   "scripts": {
+    "codegraph": "bash scripts/codegraph.sh",
     "lint": "eslint ./modules/**/*.js",
     "format": "npm run lint -- --fix",
     "test": "jest",

--- a/scripts/codegraph.sh
+++ b/scripts/codegraph.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build or update this repo's local code knowledge graph (.codegraph/codegraph.db).
+#
+# Idempotent — safe to run any time:
+#   (no args)   first run -> init (full index); after that -> sync (fast, incremental)
+#   --force     rebuild the graph from scratch
+#
+# The DB is gitignored and local to your machine; only .codegraph/.gitignore is
+# committed. Engine: https://github.com/colbymchenry/codegraph (run via npx, no
+# global or project install required).
+set -u
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENGINE="@colbymchenry/codegraph@^1.1.0"
+export CODEGRAPH_TELEMETRY="${CODEGRAPH_TELEMETRY:-0}"
+
+case "${1:-}" in
+  --force)
+    echo "[codegraph] rebuild: $DIR"
+    npx -y "$ENGINE" index "$DIR"
+    ;;
+  *)
+    if [ -f "$DIR/.codegraph/codegraph.db" ]; then
+      echo "[codegraph] update (sync): $DIR"
+      npx -y "$ENGINE" sync "$DIR"
+    else
+      echo "[codegraph] init: $DIR"
+      npx -y "$ENGINE" init "$DIR"
+    fi
+    ;;
+esac


### PR DESCRIPTION
Introduce a code knowledge graph for search/read operations.

Adds the `.codegraph/.gitignore` marker so the CodeGraph directory is established in-repo while its local data (DB, logs, sockets) stays ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ignore rules to keep local CodeGraph working data out of version control.
  * Clarified that CodeGraph files are stored locally and won’t be committed by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->